### PR TITLE
Bug hsb with brightness

### DIFF
--- a/lib/src/models/hsb_color.dart
+++ b/lib/src/models/hsb_color.dart
@@ -91,7 +91,7 @@ class HsbColor extends cm.HsbColor
   }
 
   @override
-  HsbColor withBrightness(num value) {
+  HsbColor withBrightness(num brightness) {
     assert(value != null && value >= 0 && value <= 100);
 
     return HsbColor(hue, saturation, brightness, alpha);

--- a/lib/src/models/hsb_color.dart
+++ b/lib/src/models/hsb_color.dart
@@ -92,7 +92,7 @@ class HsbColor extends cm.HsbColor
 
   @override
   HsbColor withBrightness(num brightness) {
-    assert(value != null && value >= 0 && value <= 100);
+    assert(brightness != null && brightness >= 0 && brightness <= 100);
 
     return HsbColor(hue, saturation, brightness, alpha);
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,7 +113,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.2"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
@@ -157,5 +157,5 @@ packages:
     source: hosted
     version: "2.1.0-nullsafety.3"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-186.0.dev"
+  dart: ">=2.10.0-110 <2.11.0"
   flutter: ">=1.17.0 <2.0.0"


### PR DESCRIPTION
The current implementation does not update the brightness of HSB colors:

```
@override
HsbColor withBrightness(num value) {
  assert(value != null && value >= 0 && value <= 100);

  return HsbColor(hue, saturation, brightness, alpha);
}
```

I changed it to follow what you did on other `withXYZ` methods, i.e. shadowing the instance variable:

```
@override
HsbColor withBrightness(num brightness) {
  assert(brightness!= null && brightness>= 0 && brightness<= 100);

  return HsbColor(hue, saturation, brightness, alpha);
}
```

A better solution could be to use `value` for the incoming parameter:

```
@override
HsbColor withBrightness(num value) {
  assert(value != null && value >= 0 && value <= 100);

  return HsbColor(hue, saturation, value, alpha);
}
```